### PR TITLE
Also show rosdistro versions, if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,15 @@ In this example we'll use the ros2.yaml file as an example, but other `vcstool` 
 1. Install dependencies of this project: `poetry install`
 1. Gather the necessary data: `poetry run sync --config ./config/ros2.yaml`
 1. Compute the necessary data: `poetry run compute --config ./config/ros2.yaml`
-1. View the result by running an http server locally: `poetry run serve`
-1. Visit http://localhost:8000?distribution=rolling
+1. Run an http server locally: `poetry run serve`
 
 ## Generating data without poetry
 
 1. Install `vcstool`
-1. `mkdir distributions`
 1. Gather the necessary data: `PYTHONPATH=src python3 ./src/osr_dashboard/command/sync.py --config ./config/ros2.yaml`
 1. Compute the necessary data: `PYTHONPATH=src python3 ./src/osr_dashboard/command/compute.py --config ./config/ros2.yaml`
+1. Run an http server locally: `PYTHONPATH=src python3 ./src/osr_dashboard/command/serve.py`
 
 # Viewing the result
 
-1. Run an http server locally: `cd pages ; python3 -m http.server`
-1. Visit http://localhost:8000?distribution=rolling
+Visit http://localhost:8000?distribution=rolling

--- a/config/ros2.yaml
+++ b/config/ros2.yaml
@@ -3,11 +3,4 @@ distributions:
     url: https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos
   rolling:
     url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
-    rosdistro:
-      url: https://raw.githubusercontent.com/ros/rosdistro/master/rolling/distribution.yaml
-      ros2_repos_to_rosdistro_name_map:
-        Fast-CDR: fastcdr
-        Fast-DDS: fastrtps
-        gz_cmake2_vendor: ignition_cmake2_vendor
-        gz_math6_vendor: ignition_math6_vendor
-        ros_tutorials: turtlesim
+    rosdistro_url: https://raw.githubusercontent.com/ros/rosdistro/master/rolling/distribution.yaml

--- a/config/ros2.yaml
+++ b/config/ros2.yaml
@@ -3,3 +3,11 @@ distributions:
     url: https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos
   rolling:
     url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+    rosdistro:
+      url: https://raw.githubusercontent.com/ros/rosdistro/master/rolling/distribution.yaml
+      ros2_repos_to_rosdistro_name_map:
+        Fast-CDR: fastcdr
+        Fast-DDS: fastrtps
+        gz_cmake2_vendor: ignition_cmake2_vendor
+        gz_math6_vendor: ignition_math6_vendor
+        ros_tutorials: turtlesim

--- a/pages/index.html
+++ b/pages/index.html
@@ -138,6 +138,7 @@
           searchable: false,
         },
         {
+          field: 'days_since_commit',
           title: 'Days since commit',
           searchable: false,
           formatter: (value, row) => {
@@ -147,6 +148,7 @@
           }
         },
         {
+          field: 'days_since_release',
           title: 'Days since release',
           searchable: false,
           formatter: (value, row) => {
@@ -156,15 +158,36 @@
           }
         },
         {
+          field: 'commits_since_release',
           title: 'Commits since release',
           formatter: commitDeltaFormatter,
           searchable: false
         },
         {
-          field: 'latest_tag.name',
+          field: 'latest_source_tag',
           searchable: false,
           title: 'Latest Source Tag',
           formatter: tagFormatter
+        },
+        {
+          field: 'latest_rosdistro_tag',
+          title: 'Latest rosdistro Tag',
+          searchable: false,
+          formatter: (value, row) => {
+            // This is a little subtle, but if rosdistro_version is undefined,
+            // we assume that there is no rosdistro_version for the entire
+            // table and hide the column.  If the rosdistro_version is the
+            // empty string, we just assume that this package has no rosdistro
+            // released version.
+            // This isn't quite right, but was the only thing I could figure out
+            // without fetching and parsing the JSON twice.
+            if (row.rosdistro_version === undefined) {
+              $table.bootstrapTable('hideColumn', 'latest_rosdistro_tag')
+              return ""
+            }
+
+            return row.rosdistro_version.split("-")[0]
+          }
         },
       ]
     })

--- a/pages/index.html
+++ b/pages/index.html
@@ -54,7 +54,6 @@
   const distribution = params.get("distribution");
 
   function responseHandler(res) {
-
     const date = new Date(res.generation_time)
 
     $head.text('Distribution Status: ' + res.name)
@@ -63,62 +62,57 @@
   }
 
   function nameFormatter(value, row) {
-      return '<a href="' + row.url + '">' + row.name + '</a>'
+    return '<a href="' + row.url + '">' + row.name + '</a>'
   }
 
   function branchFormatter(value, row) {
-      if (row.branch)
-        return '<a href="' + row.branch.url + '">' + row.branch.name + '</a>'
-      else
-        return "DETACHED"
+    if (row.branch) {
+      return '<a href="' + row.branch.url + '">' + row.branch.name + '</a>'
+    } else {
+      return "DETACHED"
+    }
   }
 
   function commitFormatter(value, row) {
-      const options = {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-     };
+    const options = {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+   };
 
-      const date = new Date(row.latest_commit.commit_date)
+    const date = new Date(row.latest_commit.commit_date)
 
-      ret = '<a href="' + row.latest_commit.url + '">' + row.latest_commit.SHA.slice(0,8) + '</a>'
-      ret += '<br/>' + row.latest_commit.author
-      ret += '<br/>' + date.toLocaleString('en-US', options)
-      return ret
+    ret = '<a href="' + row.latest_commit.url + '">' + row.latest_commit.SHA.slice(0,8) + '</a>'
+    ret += '<br/>' + row.latest_commit.author
+    ret += '<br/>' + date.toLocaleString('en-US', options)
+    return ret
   }
 
   function tagFormatter(value, row) {
-      if (row.latest_tag === undefined)
-        return "DETACHED"
+    if (row.latest_tag === undefined) {
+      return "DETACHED"
+    }
 
-      const options = {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-     };
-      const date = new Date(row.latest_tag.commit_date)
+    const options = {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    };
+    const date = new Date(row.latest_tag.commit_date)
 
-      ret = '<a href="' + row.latest_tag.url+ '">' + row.latest_tag.name+ '</a>'
-      ret += '<br/>' + row.latest_tag.author
-      ret += '<br/>' + date.toLocaleString('en-US', options)
-      return ret
+    ret = '<a href="' + row.latest_tag.url+ '">' + row.latest_tag.name+ '</a>'
+    ret += '<br/>' + row.latest_tag.author
+    ret += '<br/>' + date.toLocaleString('en-US', options)
+    return ret
   }
 
   function commitDeltaFormatter(value, row) {
-      if (row.release_delta === undefined)
-        return "DETACHED"
-
-      ret = '<a href="'  + row.release_delta.url + '">' + row.release_delta.commit_count + '</a>'
-      return ret
-  }
-
-  function daysSinceRelease(value, row) {
+    if (row.release_delta === undefined) {
+      return "DETACHED"
     }
 
-  function diffstatFormatter(index, row) {
-      console.log(row)
-      return row.release_delta.diffstat.join('<br/>');
+    ret = '<a href="'  + row.release_delta.url + '">' + row.release_delta.commit_count + '</a>'
+    return ret
   }
 
   function initTable() {

--- a/pages/index.html
+++ b/pages/index.html
@@ -147,12 +147,6 @@
           }
         },
         {
-          field: 'latest_tag.name',
-          searchable: false,
-          title: 'Latest Tag',
-          formatter: tagFormatter
-        },
-        {
           title: 'Days since release',
           searchable: false,
           formatter: (value, row) => {
@@ -165,6 +159,12 @@
           title: 'Commits since release',
           formatter: commitDeltaFormatter,
           searchable: false
+        },
+        {
+          field: 'latest_tag.name',
+          searchable: false,
+          title: 'Latest Source Tag',
+          formatter: tagFormatter
         },
       ]
     })

--- a/pages/index.html
+++ b/pages/index.html
@@ -58,6 +58,11 @@
 
     $head.text('Distribution Status: ' + res.name)
     $generated.text('Generated on: ' + date)
+
+    if (!res.has_rosdistro_data) {
+      $table.bootstrapTable('hideColumn', 'latest_rosdistro_tag')
+    }
+
     return res.repos
   }
 
@@ -174,15 +179,7 @@
           title: 'Latest rosdistro Tag',
           searchable: false,
           formatter: (value, row) => {
-            // This is a little subtle, but if rosdistro_version is undefined,
-            // we assume that there is no rosdistro_version for the entire
-            // table and hide the column.  If the rosdistro_version is the
-            // empty string, we just assume that this package has no rosdistro
-            // released version.
-            // This isn't quite right, but was the only thing I could figure out
-            // without fetching and parsing the JSON twice.
             if (row.rosdistro_version === undefined) {
-              $table.bootstrapTable('hideColumn', 'latest_rosdistro_tag')
               return ""
             }
 

--- a/src/osr_dashboard/command/compute.py
+++ b/src/osr_dashboard/command/compute.py
@@ -150,6 +150,10 @@ def compute_repo_stats(repo: Repository, generation_time: datetime.datetime):
             "head_to_now": timedelta_to_json(generation_time - head_dt),
             "diffstat": diffstat.split("\n"),
         }
+
+    if repo.rosdistro_version is not None:
+        ret["rosdistro_version"] = repo.rosdistro_version
+
     return ret
 
 

--- a/src/osr_dashboard/command/compute.py
+++ b/src/osr_dashboard/command/compute.py
@@ -166,6 +166,7 @@ def compute_distro_stats(distro: Distribution) -> Dict[str, Any]:
     ret["name"] = distro.name
     ret["url"] = distro.url
     ret["generation_time"] = now.isoformat()
+    ret["has_rosdistro_data"] = distro.rosdistro_url is not None
     ret["repos"] = []
     for repo in distro.repos.values():
         ret["repos"].append(compute_repo_stats(repo, now))

--- a/src/osr_dashboard/distribution.py
+++ b/src/osr_dashboard/distribution.py
@@ -2,7 +2,6 @@ import os
 from typing import Dict, List
 
 import requests
-
 import yaml
 from vcstool.commands.import_ import add_dependencies, get_repositories
 from vcstool.executor import execute_jobs, output_results

--- a/src/osr_dashboard/distribution.py
+++ b/src/osr_dashboard/distribution.py
@@ -47,27 +47,17 @@ class Distribution:
                     f"rosdistro data from {self.rosdistro_url} is not valid yaml format: {ex}"
                 ) from ex
 
-            for repo_name, repo in rosdistro_yaml["repositories"].items():
-                if "source" not in repo:
+            for repo in rosdistro_yaml["repositories"].values():
+                if "source" not in repo or "url" not in repo["source"]:
                     # No source entry, no key to add
                     continue
 
-                if "url" not in repo["source"]:
-                    # No source URL, no key to add
-                    continue
-
-                if "release" not in repo:
+                if "release" not in repo or "version" not in repo["release"]:
                     # No release entry, no value to add
                     continue
 
-                if "version" not in repo["release"]:
-                    # No version, no value to add
-                    continue
-
                 source_url = repo["source"]["url"]
-                version = repo["release"]["version"]
-
-                rosdistro_url_to_version[source_url] = version
+                rosdistro_url_to_version[source_url] = repo["release"]["version"]
 
         for local_path, entry in config.items():
             rosdistro_version = None

--- a/src/osr_dashboard/distribution.py
+++ b/src/osr_dashboard/distribution.py
@@ -15,20 +15,29 @@ class Distribution:
     """Class for keeping track of a software distribution"""
 
     def get_rosdistro_version(self, rosdistro_repo_data):
-        rosdistro_version = ''
+        rosdistro_version = ""
 
-        if 'release' in rosdistro_repo_data:
-            rosdistro_release_data = rosdistro_repo_data['release']
-            if 'version' in rosdistro_release_data:
-                rosdistro_version = rosdistro_release_data['version']
+        if "release" in rosdistro_repo_data:
+            rosdistro_release_data = rosdistro_repo_data["release"]
+            if "version" in rosdistro_release_data:
+                rosdistro_version = rosdistro_release_data["version"]
 
         return rosdistro_version
 
-    def __init__(self, name: str, url: str, rosdistro_url: str, ros2_repos_to_rosdistro_name_map: Dict[str, str], cache_root: str) -> None:
+    def __init__(
+        self,
+        name: str,
+        url: str,
+        rosdistro_url: str,
+        ros2_repos_to_rosdistro_name_map: Dict[str, str],
+        cache_root: str,
+    ) -> None:
         self.name: str = name
         self.url: str = url
         self.rosdistro_url: str = rosdistro_url
-        self.ros2_repos_to_rosdistro_name_map: Dict[str, str] = ros2_repos_to_rosdistro_name_map
+        self.ros2_repos_to_rosdistro_name_map: Dict[
+            str, str
+        ] = ros2_repos_to_rosdistro_name_map
         self._cache_dir = (
             os.path.join(os.path.curdir, "distributions")
             if cache_root == ""
@@ -41,26 +50,36 @@ class Distribution:
         if self.rosdistro_url is not None:
             response = requests.get(self.rosdistro_url)
             if response.status_code != 200:
-                raise RuntimeError(f'Failed to get data from {self.rosdistro_url}: {response.reason}')
+                raise RuntimeError(
+                    f"Failed to get data from {self.rosdistro_url}: {response.reason}"
+                )
 
             try:
                 rosdistro_yaml = yaml.safe_load(response.text)
             except yaml.YAMLError as ex:
-                raise RuntimeError(f"rosdistro data from {self.rosdistro_url} is not valid yaml format: {ex}") from ex
+                raise RuntimeError(
+                    f"rosdistro data from {self.rosdistro_url} is not valid yaml format: {ex}"
+                ) from ex
 
         for local_path, entry in config.items():
             rosdistro_version = None
             if self.rosdistro_url is not None:
                 # If we have a rosdistro_url, make sure that all repositories can be resolved in it
-                repo_name_only = local_path.split('/')[-1]
-                if repo_name_only in rosdistro_yaml['repositories']:
-                    rosdistro_version = self.get_rosdistro_version(rosdistro_yaml['repositories'][repo_name_only])
+                repo_name_only = local_path.split("/")[-1]
+                if repo_name_only in rosdistro_yaml["repositories"]:
+                    rosdistro_version = self.get_rosdistro_version(
+                        rosdistro_yaml["repositories"][repo_name_only]
+                    )
                 else:
                     if repo_name_only not in self.ros2_repos_to_rosdistro_name_map:
-                        raise RuntimeError(f'Could not find ros2 repository {repo_name_only} in rosdistro or in the map')
+                        raise RuntimeError(
+                            f"Could not find ros2 repository {repo_name_only} in rosdistro or in the map"
+                        )
 
                     alt_name = self.ros2_repos_to_rosdistro_name_map[repo_name_only]
-                    rosdistro_version = self.get_rosdistro_version(rosdistro_yaml['repositories'][alt_name])
+                    rosdistro_version = self.get_rosdistro_version(
+                        rosdistro_yaml["repositories"][alt_name]
+                    )
 
             self.repos[local_path] = Repository(
                 local_path=local_path,
@@ -106,13 +125,25 @@ def _parse_distributions(yaml_file, cache_root: str) -> List[Distribution]:
             rosdistro_url = None
             if "rosdistro" in values:
                 if "url" not in values["rosdistro"]:
-                    raise RuntimeError("rosdistro section specified, but no 'url' given")
+                    raise RuntimeError(
+                        "rosdistro section specified, but no 'url' given"
+                    )
                 rosdistro_url = values["rosdistro"]["url"]
 
                 if "ros2_repos_to_rosdistro_name_map" in values["rosdistro"]:
-                    ros2_repos_to_rosdistro_name_map = values["rosdistro"]["ros2_repos_to_rosdistro_name_map"]
+                    ros2_repos_to_rosdistro_name_map = values["rosdistro"][
+                        "ros2_repos_to_rosdistro_name_map"
+                    ]
 
-            ret.append(Distribution(distro_name, values["url"], rosdistro_url, ros2_repos_to_rosdistro_name_map, cache_root))
+            ret.append(
+                Distribution(
+                    distro_name,
+                    values["url"],
+                    rosdistro_url,
+                    ros2_repos_to_rosdistro_name_map,
+                    cache_root,
+                )
+            )
         return ret
     except KeyError as ex:
         raise RuntimeError(f"Input data is not valid format: {ex}") from ex

--- a/src/osr_dashboard/distribution.py
+++ b/src/osr_dashboard/distribution.py
@@ -14,6 +14,16 @@ from osr_dashboard.util import resolve_uri
 class Distribution:
     """Class for keeping track of a software distribution"""
 
+    def get_rosdistro_version(self, rosdistro_repo_data):
+        rosdistro_version = ''
+
+        if 'release' in rosdistro_repo_data:
+            rosdistro_release_data = rosdistro_repo_data['release']
+            if 'version' in rosdistro_release_data:
+                rosdistro_version = rosdistro_release_data['version']
+
+        return rosdistro_version
+
     def __init__(self, name: str, url: str, rosdistro_url: str, ros2_repos_to_rosdistro_name_map: Dict[str, str], cache_root: str) -> None:
         self.name: str = name
         self.url: str = url
@@ -31,38 +41,26 @@ class Distribution:
         if self.rosdistro_url is not None:
             response = requests.get(self.rosdistro_url)
             if response.status_code != 200:
-                raise RuntimeException(f'Failed to get data from {self.rosdistro_url}: {response.reason}')
+                raise RuntimeError(f'Failed to get data from {self.rosdistro_url}: {response.reason}')
 
             try:
                 rosdistro_yaml = yaml.safe_load(response.text)
             except yaml.YAMLError as ex:
-                raise RuntimeError(f'rosdistro URL {self.rosdistro_url} is not valid YAML')
-                return False
+                raise RuntimeError(f"rosdistro data from {self.rosdistro_url} is not valid yaml format: {ex}") from ex
 
         for local_path, entry in config.items():
-            repo_name_only = local_path.split('/')[-1]
-            if repo_name_only in self.ros2_repos_to_rosdistro_name_map:
-                alt_name = self.ros2_repos_to_rosdistro_name_map[repo_name_only]
-            else:
-                alt_name = repo_name_only
-
             rosdistro_version = None
             if self.rosdistro_url is not None:
                 # If we have a rosdistro_url, make sure that all repositories can be resolved in it
-                rosdistro_version = ''
-                key = ''
+                repo_name_only = local_path.split('/')[-1]
                 if repo_name_only in rosdistro_yaml['repositories']:
-                    key = repo_name_only
-                elif alt_name in rosdistro_yaml['repositories']:
-                    key = alt_name
+                    rosdistro_version = self.get_rosdistro_version(rosdistro_yaml['repositories'][repo_name_only])
                 else:
-                    raise RuntimeError(f'Could not find ros2 repos repository {repo_name_only} in rosdistro')
+                    if repo_name_only not in self.ros2_repos_to_rosdistro_name_map:
+                        raise RuntimeError(f'Could not find ros2 repository {repo_name_only} in rosdistro or in the map')
 
-                rosdistro_repo_data = rosdistro_yaml['repositories'][key]
-                if 'release' in rosdistro_repo_data:
-                    rosdistro_release_data = rosdistro_repo_data['release']
-                    if 'version' in rosdistro_release_data:
-                        rosdistro_version = rosdistro_release_data['version']
+                    alt_name = self.ros2_repos_to_rosdistro_name_map[repo_name_only]
+                    rosdistro_version = self.get_rosdistro_version(rosdistro_yaml['repositories'][alt_name])
 
             self.repos[local_path] = Repository(
                 local_path=local_path,
@@ -107,7 +105,7 @@ def _parse_distributions(yaml_file, cache_root: str) -> List[Distribution]:
             ros2_repos_to_rosdistro_name_map = {}
             rosdistro_url = None
             if "rosdistro" in values:
-                if not "url" in values["rosdistro"]:
+                if "url" not in values["rosdistro"]:
                     raise RuntimeError("rosdistro section specified, but no 'url' given")
                 rosdistro_url = values["rosdistro"]["url"]
 

--- a/src/osr_dashboard/distribution.py
+++ b/src/osr_dashboard/distribution.py
@@ -1,6 +1,8 @@
 import os
 from typing import Dict, List
 
+import requests
+
 import yaml
 from vcstool.commands.import_ import add_dependencies, get_repositories
 from vcstool.executor import execute_jobs, output_results
@@ -12,9 +14,11 @@ from osr_dashboard.util import resolve_uri
 class Distribution:
     """Class for keeping track of a software distribution"""
 
-    def __init__(self, name: str, url: str, cache_root: str) -> None:
+    def __init__(self, name: str, url: str, rosdistro_url: str, ros2_repos_to_rosdistro_name_map: Dict[str, str], cache_root: str) -> None:
         self.name: str = name
         self.url: str = url
+        self.rosdistro_url: str = rosdistro_url
+        self.ros2_repos_to_rosdistro_name_map: Dict[str, str] = ros2_repos_to_rosdistro_name_map
         self._cache_dir = (
             os.path.join(os.path.curdir, "distributions")
             if cache_root == ""
@@ -24,11 +28,47 @@ class Distribution:
         self.repos: Dict[str, Repository] = {}
         config = get_repositories(resolve_uri(url))
 
+        if self.rosdistro_url is not None:
+            response = requests.get(self.rosdistro_url)
+            if response.status_code != 200:
+                raise RuntimeException(f'Failed to get data from {self.rosdistro_url}: {response.reason}')
+
+            try:
+                rosdistro_yaml = yaml.safe_load(response.text)
+            except yaml.YAMLError as ex:
+                raise RuntimeError(f'rosdistro URL {self.rosdistro_url} is not valid YAML')
+                return False
+
         for local_path, entry in config.items():
+            repo_name_only = local_path.split('/')[-1]
+            if repo_name_only in self.ros2_repos_to_rosdistro_name_map:
+                alt_name = self.ros2_repos_to_rosdistro_name_map[repo_name_only]
+            else:
+                alt_name = repo_name_only
+
+            rosdistro_version = None
+            if self.rosdistro_url is not None:
+                # If we have a rosdistro_url, make sure that all repositories can be resolved in it
+                rosdistro_version = ''
+                key = ''
+                if repo_name_only in rosdistro_yaml['repositories']:
+                    key = repo_name_only
+                elif alt_name in rosdistro_yaml['repositories']:
+                    key = alt_name
+                else:
+                    raise RuntimeError(f'Could not find ros2 repos repository {repo_name_only} in rosdistro')
+
+                rosdistro_repo_data = rosdistro_yaml['repositories'][key]
+                if 'release' in rosdistro_repo_data:
+                    rosdistro_release_data = rosdistro_repo_data['release']
+                    if 'version' in rosdistro_release_data:
+                        rosdistro_version = rosdistro_release_data['version']
+
             self.repos[local_path] = Repository(
                 local_path=local_path,
                 vcs_entry=entry,
                 distro_root=self.path,
+                rosdistro_version=rosdistro_version,
             )
 
     @property
@@ -64,7 +104,17 @@ def _parse_distributions(yaml_file, cache_root: str) -> List[Distribution]:
     try:
         ret = []
         for distro_name, values in root["distributions"].items():
-            ret.append(Distribution(distro_name, values["url"], cache_root))
+            ros2_repos_to_rosdistro_name_map = {}
+            rosdistro_url = None
+            if "rosdistro" in values:
+                if not "url" in values["rosdistro"]:
+                    raise RuntimeError("rosdistro section specified, but no 'url' given")
+                rosdistro_url = values["rosdistro"]["url"]
+
+                if "ros2_repos_to_rosdistro_name_map" in values["rosdistro"]:
+                    ros2_repos_to_rosdistro_name_map = values["rosdistro"]["ros2_repos_to_rosdistro_name_map"]
+
+            ret.append(Distribution(distro_name, values["url"], rosdistro_url, ros2_repos_to_rosdistro_name_map, cache_root))
         return ret
     except KeyError as ex:
         raise RuntimeError(f"Input data is not valid format: {ex}") from ex
@@ -76,7 +126,6 @@ def get_distributions(uri, cache_root: str) -> List[Distribution]:
     """
     uri = resolve_uri(uri)
     try:
-        distributions = _parse_distributions(uri, cache_root)
-        return distributions
+        return _parse_distributions(uri, cache_root)
     except (yaml.YAMLError, KeyError) as ex:
         raise RuntimeError("Input data in not valid YAML format: {ex}") from ex

--- a/src/osr_dashboard/repository.py
+++ b/src/osr_dashboard/repository.py
@@ -41,7 +41,11 @@ class Repository:
     """A single entry in a distribution"""
 
     def __init__(
-        self, local_path: str, vcs_entry: Dict[str, str], distro_root: str, rosdistro_version: Optional[str]
+        self,
+        local_path: str,
+        vcs_entry: Dict[str, str],
+        distro_root: str,
+        rosdistro_version: Optional[str],
     ) -> None:
         self._local_path: str = local_path
         self._distro_root: str = distro_root

--- a/src/osr_dashboard/repository.py
+++ b/src/osr_dashboard/repository.py
@@ -41,10 +41,11 @@ class Repository:
     """A single entry in a distribution"""
 
     def __init__(
-        self, local_path: str, vcs_entry: Dict[str, str], distro_root: str
+        self, local_path: str, vcs_entry: Dict[str, str], distro_root: str, rosdistro_version: Optional[str]
     ) -> None:
         self._local_path: str = local_path
-        self._distro_root = distro_root
+        self._distro_root: str = distro_root
+        self._rosdistro_version: Optional[str] = rosdistro_version
 
         self._type: str = vcs_entry["type"]
         self._remote_url: str = vcs_entry["url"]
@@ -119,6 +120,13 @@ class Repository:
         if len(tags) != 0:
             return tags[0]
         return None
+
+    @property
+    def rosdistro_version(self) -> Optional[str]:
+        """
+        Get the rosdistro version, if any
+        """
+        return self._rosdistro_version
 
     def import_job(self, shallow: bool = False, recursive: bool = False):
         """

--- a/src/osr_dashboard/repository.py
+++ b/src/osr_dashboard/repository.py
@@ -60,7 +60,7 @@ class Repository:
     @property
     def github_info(self) -> Optional[Tuple[str, str]]:
         """
-        Get the github owner/name infor for this repository
+        Get the github owner/name information for this repository
         """
         github_url = "https://github.com/"
         if self._remote_url.find(github_url) >= 0:

--- a/src/osr_dashboard/util.py
+++ b/src/osr_dashboard/util.py
@@ -34,5 +34,5 @@ def existing_dir(path):
     """
     if os.path.exists(path) and not os.path.isdir(path):
         raise argparse.ArgumentTypeError(f"Path '{path}' is not a directory.")
-    # implicitly, we allow the path to not exist; we assume something later one will create it
+    # implicitly, we allow the path to not exist; we assume something later on will create it
     return path

--- a/src/osr_dashboard/util.py
+++ b/src/osr_dashboard/util.py
@@ -30,11 +30,9 @@ def file_or_url_type(value):
 
 def existing_dir(path):
     """
-    Function to check if a directory is existing for argparse
-
+    Function to check if a given path is a directory for argparse
     """
-    if not os.path.exists(path):
-        raise argparse.ArgumentTypeError(f"Path '{path}' does not exist.")
-    if not os.path.isdir(path):
+    if os.path.exists(path) and not os.path.isdir(path):
         raise argparse.ArgumentTypeError(f"Path '{path}' is not a directory.")
+    # implicitly, we allow the path to not exist; we assume something later one will create it
     return path


### PR DESCRIPTION
This PR does a bit of refactoring, and then adds functionality so we can show the rosdistro versions as a new column.  It does this by taking a URL to the rosdistro <distro>/distributions.yaml file, e.g. https://raw.githubusercontent.com/ros/rosdistro/master/rolling/distribution.yaml .

Using that information, it can figure out what the latest released rosdistro version is, and display that.

If the rosdistro_url was configured, then an additional column (Latest rosdistro tag) will be shown, with the information (assuming it was actually released).