### PR TITLE
Fix truncated URLs in Gazebo.

### DIFF
--- a/src/osr_dashboard/repository.py
+++ b/src/osr_dashboard/repository.py
@@ -71,7 +71,7 @@ class Repository:
             repo_name = url_tuple[1]
 
             dot_git = repo_name.find(".git")
-            if dot_git:
+            if dot_git >= 0:
                 repo_name = repo_name[:dot_git]
             return (repo_owner, repo_name)
         return None


### PR DESCRIPTION
In Python, if str.find() doesn't find what it is looking for, it returns -1.  But the check for this wasn't taking this into account, meaning that if repos were missing '.git', they would get the last letter truncated.  Fix that here.

Fixes #9 