### PR TITLE
Add rmf repos

### DIFF
--- a/config/rmf.yaml
+++ b/config/rmf.yaml
@@ -1,0 +1,10 @@
+distributions:
+  rmf-humble:
+    url: https://raw.githubusercontent.com/open-rmf/rmf/humble/rmf.repos
+    rosdistro_url: https://raw.githubusercontent.com/ros/rosdistro/master/humble/distribution.yaml
+  rmf-iron:
+    url: https://raw.githubusercontent.com/open-rmf/rmf/iron/rmf.repos
+    rosdistro_url: https://raw.githubusercontent.com/ros/rosdistro/master/iron/distribution.yaml
+  rmf-rolling:
+    url: https://raw.githubusercontent.com/open-rmf/rmf/main/rmf.repos
+    rosdistro_url: https://raw.githubusercontent.com/ros/rosdistro/master/rolling/distribution.yaml

--- a/pages/index.html
+++ b/pages/index.html
@@ -38,6 +38,12 @@
       <li><a href="?distribution=garden">Garden</a></li>
     </ul>
 
+    <ul>
+      <li><a href="?distribution=rmf-humble">Open-RMF-Humble</a></li>
+      <li><a href="?distribution=rmf-iron">Open-RMF-Iron</a></li>
+      <li><a href="?distribution=rmf-rolling">Open-RMF-Rolling</a></li>
+    </ul>
+
     <div class="row">
       <table
         class="table table-striped table-sm"


### PR DESCRIPTION
The `osr_dashboard` is extremely useful for inferring which packages have had changes since the last release. Having one for open-rmf will greatly benefit the release process for open-rmf given that we have a collection of repos for this project as well. I'm open to changing any of the labels I've added.

Tested locally and seems to work fine

<img width="1628" alt="image" src="https://github.com/osrf/osr_dashboard/assets/13482049/5e28113c-4bba-4e23-8ca6-2b01bb3a358d">
